### PR TITLE
updates version 0.3.25

### DIFF
--- a/demos/js/meshflow/workflows.js
+++ b/demos/js/meshflow/workflows.js
@@ -15,9 +15,9 @@ async function example(name, lang) {
   await MeshFlow.workflow.sleepFor('1 second');
 
   await MeshFlow.workflow.trace({
-    strng: 'example',
-    nmbr: 42,
-    bln: true,
+    'app.custom.string': 'example',
+    'app.custom.number': 42,
+    'app.custom.boolean': true,
   });
 
   //execute a proxied activity

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "samples-typescript",
-  "version": "0.3.24",
+  "version": "0.3.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "samples-typescript",
-      "version": "0.3.24",
+      "version": "0.3.25",
       "license": "Apache-2.0",
       "dependencies": {
         "@honeycombio/opentelemetry-node": "^0.7.2",
         "@hotmeshio/dashboard": "^0.3.7",
-        "@hotmeshio/hotmesh": "^0.3.24",
+        "@hotmeshio/hotmesh": "^0.3.25",
         "@opentelemetry/auto-instrumentations-node": "^0.47.1",
         "@opentelemetry/sdk-node": "^0.52.1",
         "cors": "^2.8.5",
@@ -939,9 +939,9 @@
       "integrity": "sha512-AL2jsvPpckFOD08C/YrzQjnS//b6+0PEBsLuDd4LzJ56Q6dOTof+tNEBeNgJzp3TzOEVjTvHnwznpmz98Dy7vA=="
     },
     "node_modules/@hotmeshio/hotmesh": {
-      "version": "0.3.24",
-      "resolved": "https://registry.npmjs.org/@hotmeshio/hotmesh/-/hotmesh-0.3.24.tgz",
-      "integrity": "sha512-TRS9vcN2KRguMIe9axTuGjrlaGTtj0kWTWHEI5pFbaPgHCVMhu/APiKvC21TNTpFeWSikyULXSc7Yj4YVw4itA==",
+      "version": "0.3.25",
+      "resolved": "https://registry.npmjs.org/@hotmeshio/hotmesh/-/hotmesh-0.3.25.tgz",
+      "integrity": "sha512-LJzxe1sHyTT0KyROmfxBpon4IftKEvNou8EzzSlqA/DGYm7pDRqoTBszTPFnQjRs3f1C38xquhCBG4O8BhVUAw==",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^10.1.0",
         "@opentelemetry/api": "^1.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "samples-typescript",
-  "version": "0.3.24",
+  "version": "0.3.25",
   "description": "HotMesh TypeScript Samples",
   "scripts": {
     "clean": "rimraf ./build",
@@ -54,7 +54,7 @@
   "dependencies": {
     "@honeycombio/opentelemetry-node": "^0.7.2",
     "@hotmeshio/dashboard": "^0.3.7",
-    "@hotmeshio/hotmesh": "^0.3.24",
+    "@hotmeshio/hotmesh": "^0.3.25",
     "@opentelemetry/auto-instrumentations-node": "^0.47.1",
     "@opentelemetry/sdk-node": "^0.52.1",
     "cors": "^2.8.5",


### PR DESCRIPTION
version 0.3.25
- fixes open telemetry missing attributes (early server shutdown sometimes missed various attributes; this fix ensures every attribute is set by explicitly calling `set`).